### PR TITLE
Add exercise rust-1-a

### DIFF
--- a/config.json
+++ b/config.json
@@ -70,6 +70,14 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": []
+    },
+    {
+      "slug": "rust-1-a",
+      "uuid": "0ea9c484-612f-4fb5-b2fe-6fe04d1d218c",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": []
     }
   ]
 }

--- a/exercises/rust-1-a/.gitignore
+++ b/exercises/rust-1-a/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/exercises/rust-1-a/Cargo.toml
+++ b/exercises/rust-1-a/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust-1-a"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]

--- a/exercises/rust-1-a/README.md
+++ b/exercises/rust-1-a/README.md
@@ -6,13 +6,13 @@ This is Part 1 of our research into how people write Rust in varying styles. Thi
 
 Your task is to find the moment when a clock's hands are perfectly aligned for a given hour. Given a standard 12-hour clock with hands which sweep continuously through time, there exists some second in each hour in which the hands are best lined up with each other. 
 
-We provide a method with the signature
+We provide a method with the signature:
 
 ```rust
 fn hands_match(hour: u8) -> u32
 ```
 
-The domain of `hour`s is `1-12` inclusive. The output must be the number of seconds after the hour at which the hands best line up.
+The range of possible values for `hour` is 1-12. The output must be the number of seconds after the hour at which the hands best line up.
 
 For example:
 

--- a/exercises/rust-1-a/README.md
+++ b/exercises/rust-1-a/README.md
@@ -1,0 +1,22 @@
+## Introduction
+
+This is Part 1 of our research into how people write Rust in varying styles. This exercise should take 10-15 minutes. There is no right or wrong way to approach it - just do what feels the most natural to you. Feel free to use books, Google or Stack Overflow, just like you would if you were programming normally, but please don't look for a complete solution to the problem as this will negatively affect the research.
+
+## Instructions
+
+Your task is to find the moment when a clock's hands are perfectly aligned for a given hour. Given a standard 12-hour clock with hands which sweep continuously through time, there exists some second in each hour in which the hands are best lined up with each other. 
+
+We provide a method with the signature
+
+```rust
+fn hands_match(hour: u8) -> u32
+```
+
+The domain of `hour`s is `1-12` inclusive. The output must be the number of seconds after the hour at which the hands best line up.
+
+For example:
+
+```rust
+// the clock's hands align at noon and midnight precisely
+assert_eq!(hands_match(12), 0);
+```

--- a/exercises/rust-1-a/example.rs
+++ b/exercises/rust-1-a/example.rs
@@ -1,0 +1,35 @@
+// input: the hour, 1-12 inclusive
+// output: seconds after the hour at which the hands are best aligned
+pub fn hands_match(mut hour: u8) -> u32 {
+    hour %= 12;
+    // let's solve this analytically.
+    //
+    // other plausible solution strategies:
+    // - brute force: iterate through the seconds, find the best match
+    // - binary search: if the minute hand position is greater than the
+    //   hour hand position, go back; otherwise, fwd
+    //
+    // to get the position of the hour hand (degrees) given the (fractional) hour:
+    //
+    //   h_hand = hour * 30
+    //
+    // to get the position of the minute hand (degrees) given the (fractional) hour:
+    //
+    //   m_hand = hour * 360
+    //
+    // note that the degree position of the hour and minute hands are not restricted
+    // to a standard 360 degree circle. the hand positions are still equal when
+    // the difference between the two is 360 * n for some n, where n is the number
+    // of times the minute hand has lapped the hour hand:
+    //
+    //   m_hand - h_hand = 360 * n
+    //   (hour * 360) - (hour * 30) = n * 360
+    //   330 * hour = n * 360
+    //   hour = n * 12 / 11
+    //
+    // however, this approach only finds the fractional hour for which the hands
+    // align; the problem asked for the seconds after the hour. Luckily, that's
+    // a straightforward modification:
+    //
+    ((hour as f64 * 12.0 / 11.0) % 1.0 * 3600.0).round() as u32
+}

--- a/exercises/rust-1-a/src/lib.rs
+++ b/exercises/rust-1-a/src/lib.rs
@@ -1,0 +1,5 @@
+// input: the hour, 1-12 inclusive
+// output: seconds after the hour at which the hands are best aligned
+pub fn hands_match(mut hour: u8) -> u32 {
+    unimplemented!()
+}

--- a/exercises/rust-1-a/tests/rust_1_a.rs
+++ b/exercises/rust-1-a/tests/rust_1_a.rs
@@ -1,0 +1,32 @@
+use rust_1_a::hands_match;
+
+macro_rules! tests {
+    ($test_func:ident {
+        $( $(#[$attr:meta])* $test_name:ident($param:expr, $expect:expr); )+
+    }) => {
+        $(
+            $(#[$attr])*
+            #[test]
+            fn $test_name() {
+                assert_eq!($test_func( $param ), $expect);
+            }
+        )+
+    }
+}
+
+tests! {
+    hands_match {
+        test_01(1,  327);
+        test_02(2,  655);
+        test_03(3,  982);
+        test_04(4,  1309);
+        test_05(5,  1636);
+        test_06(6,  1964);
+        test_07(7,  2291);
+        test_08(8,  2618);
+        test_09(9,  2945);
+        test_10(10, 3273);
+        test_11(11, 0); // these two cases are a fun degenerate result
+        test_12(12, 0); // can you work out why they act like this?
+    }
+}


### PR DESCRIPTION
This exercise is fairly straightforward. The follow-on exercise is planned
to extend this by passing in an arbitrary clock instead of a standard 12h
clock.