### PR TITLE
x86-64-assembly: Add troubleshooting section

### DIFF
--- a/exercises/x86-64-assembly-1-a/README.md
+++ b/exercises/x86-64-assembly-1-a/README.md
@@ -16,3 +16,30 @@ str_isalpha("Hello");
 ```
 
 The string is passed in the `rdi` register, and the return value should be in the `rax` register.
+
+## Troubleshooting
+
+When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that any console output will be shown too. By including the file "debug.asm" using the [%include](https://www.nasm.us/xdoc/2.14.02/html/nasmdoc4.html#section-4.6.1) directive, you gain access to some useful macros:
+
+`debugd8`, `debugd16`, `debugd32`, `debugd64`: Print a signed integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugu8`, `debugu16`, `debugu32`, `debugu64`: Print an unsigned integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugx8`, `debugx16`, `debugx32`, `debugx64`: Print a hexadecimal integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugf`: Print a floating-point number. The argument can be an `xmm` register or a memory location.
+
+`debugc`: Print a single character. The argument can be a register or a memory location with width of 8 bits.
+
+`debugs`: Print a character string. The argument can be a register or a memory location with width of 64 bits.
+
+Example usage:
+
+```nasm
+debugd8 al
+debugu16 cx
+debugx32 edx
+debugf xmm0
+debugc byte [rdi]
+debugs rsi
+```

--- a/exercises/x86-64-assembly-1-a/x86_64_assembly_1_a.asm
+++ b/exercises/x86-64-assembly-1-a/x86_64_assembly_1_a.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .text
 global str_isalpha
 str_isalpha:

--- a/exercises/x86-64-assembly-1-b/README.md
+++ b/exercises/x86-64-assembly-1-b/README.md
@@ -28,3 +28,30 @@ enum color {
 ```
 
 The enum value is passed into the function via the `rdi` register, and the return value should be stored in the `rax` register.
+
+## Troubleshooting
+
+When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that any console output will be shown too. By including the file "debug.asm" using the [%include](https://www.nasm.us/xdoc/2.14.02/html/nasmdoc4.html#section-4.6.1) directive, you gain access to some useful macros:
+
+`debugd8`, `debugd16`, `debugd32`, `debugd64`: Print a signed integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugu8`, `debugu16`, `debugu32`, `debugu64`: Print an unsigned integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugx8`, `debugx16`, `debugx32`, `debugx64`: Print a hexadecimal integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugf`: Print a floating-point number. The argument can be an `xmm` register or a memory location.
+
+`debugc`: Print a single character. The argument can be a register or a memory location with width of 8 bits.
+
+`debugs`: Print a character string. The argument can be a register or a memory location with width of 64 bits.
+
+Example usage:
+
+```nasm
+debugd8 al
+debugu16 cx
+debugx32 edx
+debugf xmm0
+debugc byte [rdi]
+debugs rsi
+```

--- a/exercises/x86-64-assembly-1-b/x86_64_assembly_1_b.asm
+++ b/exercises/x86-64-assembly-1-b/x86_64_assembly_1_b.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .text
 global color_name
 color_name:

--- a/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start1.asm
+++ b/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start1.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .text
 global str_isalpha
 str_isalpha:

--- a/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start2.asm
+++ b/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start2.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 extern isalpha
 
 section .text

--- a/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start3.asm
+++ b/exercises/x86-64-assembly-2-a/.meta/x86_64_assembly_2_a.start3.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .data
 CHAR_UPPER: equ 0x0001
 CHAR_LOWER: equ 0x0002

--- a/exercises/x86-64-assembly-2-a/README.md
+++ b/exercises/x86-64-assembly-2-a/README.md
@@ -28,3 +28,30 @@ str_isidentifier("my_variable1");
 ```
 
 The string is passed into the function via the `rdi` register, and the return value should be stored in the `rax` register.
+
+## Troubleshooting
+
+When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that any console output will be shown too. By including the file "debug.asm" using the [%include](https://www.nasm.us/xdoc/2.14.02/html/nasmdoc4.html#section-4.6.1) directive, you gain access to some useful macros:
+
+`debugd8`, `debugd16`, `debugd32`, `debugd64`: Print a signed integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugu8`, `debugu16`, `debugu32`, `debugu64`: Print an unsigned integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugx8`, `debugx16`, `debugx32`, `debugx64`: Print a hexadecimal integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugf`: Print a floating-point number. The argument can be an `xmm` register or a memory location.
+
+`debugc`: Print a single character. The argument can be a register or a memory location with width of 8 bits.
+
+`debugs`: Print a character string. The argument can be a register or a memory location with width of 64 bits.
+
+Example usage:
+
+```nasm
+debugd8 al
+debugu16 cx
+debugx32 edx
+debugf xmm0
+debugc byte [rdi]
+debugs rsi
+```

--- a/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start1.asm
+++ b/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start1.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .rodata
 red: db "RED", 0
 orange: db "ORANGE", 0

--- a/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start2.asm
+++ b/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start2.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .rodata
 red: db "RED", 0
 orange: db "ORANGE", 0

--- a/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.asm
+++ b/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.asm
@@ -1,3 +1,5 @@
+%include "debug.asm"
+
 section .rodata
 red: db "RED", 0
 orange: db "ORANGE", 0

--- a/exercises/x86-64-assembly-2-b/README.md
+++ b/exercises/x86-64-assembly-2-b/README.md
@@ -39,3 +39,30 @@ color_name(buf, RED);
 ```
 
 The user-provided buffer is passed in the `rdi` register, and the enum value in the `rsi` register.
+
+## Troubleshooting
+
+When a test fails, a message is displayed describing what went wrong and for which input. You can also use the fact that any console output will be shown too. By including the file "debug.asm" using the [%include](https://www.nasm.us/xdoc/2.14.02/html/nasmdoc4.html#section-4.6.1) directive, you gain access to some useful macros:
+
+`debugd8`, `debugd16`, `debugd32`, `debugd64`: Print a signed integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugu8`, `debugu16`, `debugu32`, `debugu64`: Print an unsigned integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugx8`, `debugx16`, `debugx32`, `debugx64`: Print a hexadecimal integer. The argument can be a register or a memory location with width of 8, 16, 32, or 64 bits respectively.
+
+`debugf`: Print a floating-point number. The argument can be an `xmm` register or a memory location.
+
+`debugc`: Print a single character. The argument can be a register or a memory location with width of 8 bits.
+
+`debugs`: Print a character string. The argument can be a register or a memory location with width of 64 bits.
+
+Example usage:
+
+```nasm
+debugd8 al
+debugu16 cx
+debugx32 edx
+debugf xmm0
+debugc byte [rdi]
+debugs rsi
+```


### PR DESCRIPTION
Should `%include "debug.asm"` be added to the stub files?