### PR TITLE
x86-64-assembly: Use 32-bit pointers

### DIFF
--- a/exercises/x86-64-assembly-1-b/.meta/example.jumptable.asm
+++ b/exercises/x86-64-assembly-1-b/.meta/example.jumptable.asm
@@ -9,20 +9,21 @@ violet: db "VIOLET", 0
 
 ; Use relative displacements to avoid fixups
 jump_table:
-dq label_red - jump_table
-dq label_orange - jump_table
-dq label_yellow - jump_table
-dq label_green - jump_table
-dq label_blue - jump_table
-dq label_indigo - jump_table
-dq label_violet - jump_table
+dd label_red - jump_table
+dd label_orange - jump_table
+dd label_yellow - jump_table
+dd label_green - jump_table
+dd label_blue - jump_table
+dd label_indigo - jump_table
+dd label_violet - jump_table
 
 section .text
 global color_name
 color_name:
     mov edi, edi
-    lea rax, [rel jump_table]
-    add rax, [rax + rdi * 8]
+    lea rdx, [rel jump_table]
+    movsx rax, dword [rdx + rdi * 4]
+    add rax, rdx
     jmp rax
 label_red:
     lea rax, [rel red]

--- a/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.asm
+++ b/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.asm
@@ -10,20 +10,21 @@ indigo: db "INDIGO", 0
 violet: db "VIOLET", 0
 
 jump_table:
-dq label_red - jump_table
-dq label_orange - jump_table
-dq label_yellow - jump_table
-dq label_green - jump_table
-dq label_blue - jump_table
-dq label_indigo - jump_table
-dq label_violet - jump_table
+dd label_red - jump_table
+dd label_orange - jump_table
+dd label_yellow - jump_table
+dd label_green - jump_table
+dd label_blue - jump_table
+dd label_indigo - jump_table
+dd label_violet - jump_table
 
 section .text
 global color_name
 color_name:
     mov edi, edi
-    lea rax, [rel jump_table]
-    add rax, [rax + rdi * 8]
+    lea rdx, [rel jump_table]
+    movsx rax, dword [rdx + rdi * 4]
+    add rax, rdx
     jmp rax
 label_red:
     lea rax, [rel red]

--- a/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.example.asm
+++ b/exercises/x86-64-assembly-2-b/.meta/x86_64_assembly_2_b.start3.example.asm
@@ -16,20 +16,21 @@ violet_len: equ $ - violet
 
 ; Use relative displacements to avoid fixups
 jump_table:
-dq label_red - jump_table
-dq label_orange - jump_table
-dq label_yellow - jump_table
-dq label_green - jump_table
-dq label_blue - jump_table
-dq label_indigo - jump_table
-dq label_violet - jump_table
+dd label_red - jump_table
+dd label_orange - jump_table
+dd label_yellow - jump_table
+dd label_green - jump_table
+dd label_blue - jump_table
+dd label_indigo - jump_table
+dd label_violet - jump_table
 
 section .text
 global color_name
 color_name:
     mov esi, esi
-    lea rax, [rel jump_table]
-    add rax, [rax + rsi * 8]
+    lea rdx, [rel jump_table]
+    movsx rax, dword [rdx + rsi * 4]
+    add rax, rdx
     jmp rax
 label_red:
     lea rsi, [rel red]


### PR DESCRIPTION
Use 32-bit pointers relative to the jump table to make it smaller.