### PR TITLE
Fix linting issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "blurb": "",
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
-  "test_pattern": "[Tt]est",
+  "test_pattern": "([Tt]est|[Ss]pec)",
   "exercises": [
     {
       "slug": "csharp-1-a",


### PR DESCRIPTION
Without this `configlet lint .` errors for the javascript exercise, which uses "spec" instead of "test."