### PR TITLE
python: Update readme to use correct method name in example

### DIFF
--- a/exercises/python-1-a/README.md
+++ b/exercises/python-1-a/README.md
@@ -11,7 +11,7 @@ We expect you to define a function `compress` that takes a single argument which
 For example:
 
 ```python
->>> encode("abbcccddddaaaaaa")
+>>> compress("abbcccddddaaaaaa")
 b'\x01a\x02b\x03c\x04d\x05a'
 ```
 


### PR DESCRIPTION
I noticed that the readme uses the `encode` function in the example, but the specification uses the `compress` function.