### PR TITLE
go: Tweak go-1-a

### DIFF
--- a/exercises/go-1-a/README.md
+++ b/exercises/go-1-a/README.md
@@ -4,7 +4,7 @@ This is Part 1 of our research into how people write Go differently. This exerci
 
 ## Instructions
 
-Your task is to define a function with the signature `Describe`, which takes a number and returns the possible descriptions of that number as a string. Besides the obvious literal representation of a number (`1` being written as `"1"`), the following units are also supported:
+Your task is to define a function named `Describe`, which takes an integer and returns the possible descriptions of that number as a string. Besides the obvious literal representation of a number (`1` being written as `"1"`), the following units are also supported:
 
 - `144` is a `"gross"`
 - `20` is a `"score"`

--- a/exercises/go-1-a/go_1_a.go
+++ b/exercises/go-1-a/go_1_a.go
@@ -1,6 +1,6 @@
 package go1a
 
-// Describe takes an amount and returns a description.
-func Describe(amount int) string {
+// Describe provides an assortment of human-readable representation of numbers.
+func Describe(number int) string {
 	panic("Please implement the Describe function")
 }

--- a/exercises/go-1-a/go_1_a_test.go
+++ b/exercises/go-1-a/go_1_a_test.go
@@ -37,6 +37,6 @@ func TestSixtyFive(t *testing.T) {
 func AssertDescribe(t *testing.T, input int, expected string) {
 	actual := Describe(input)
 	if actual != expected {
-		t.Errorf("Describe(%d) = %q, expected %q.", input, actual, expected)
+		t.Errorf("Describe(%d)\n   got: %q\n  want: %q.", input, actual, expected)
 	}
 }


### PR DESCRIPTION
This updates the README to say 'function name' rather than 'signature'
when describing just the name of Description().

It also tweaks the stub file in two ways:

1. it edits the function comment to be a bit more go-ish (sorry), and
2. it renames the function parameter to `number` rather than `amount`,
since this is a countable, not a measurable.

Lastly, I updated the output from the test failures to make it a bit
more obvious what the 'got' vs the 'want' is (got and want are the
canonical terms used by the Go team, so I went with that).

    --- FAIL: TestTwelve (0.00s)
        go_1_a_test.go:40: Describe(12)
               got: "12"
              want: "1 dozen or 12".