### PR TITLE
rewrite rust-n-a

### DIFF
--- a/exercises/rust-1-a/.meta/config.json
+++ b/exercises/rust-1-a/.meta/config.json
@@ -1,77 +1,43 @@
 {
-  "solution_files": ["src/lib.rs"],
+  "solution_files": [
+    "src/lib.rs"
+  ],
   "tests": [
     {
-      "test": "test_01",
-      "name": "01",
-      "cmd": "hands_match(01)",
-      "expected": "327"
+      "test": "test_example",
+      "name": "Example",
+      "cmd": "longest_incrementing_subslice(&[1, 2, 4, 4, 5, 6, 7, 3, 2, 7, 8, 9, 1])",
+      "expected": "&[4, 5, 6, 7]"
     },
     {
-      "test": "test_02",
-      "name": "02",
-      "cmd": "hands_match(02)",
-      "expected": "655"
+      "test": "test_head",
+      "name": "Head",
+      "cmd": "longest_incrementing_subslice(&[1, 2, 3, 5])",
+      "expected": "&[1, 2, 3]"
     },
     {
-      "test": "test_03",
-      "name": "03",
-      "cmd": "hands_match(03)",
-      "expected": "982"
+      "test": "test_tail",
+      "name": "Tail",
+      "cmd": "longest_incrementing_subslice(&[8, 1, 2, 3])",
+      "expected": "&[1, 2, 3]"
     },
     {
-      "test": "test_04",
-      "name": "04",
-      "cmd": "hands_match(04)",
-      "expected": "1309"
+      "test": "test_full",
+      "name": "Full",
+      "cmd": "longest_incrementing_subslice(&[1, 2, 3])",
+      "expected": "&[1, 2, 3]"
     },
     {
-      "test": "test_05",
-      "name": "05",
-      "cmd": "hands_match(05)",
-      "expected": "1636"
+      "test": "test_min",
+      "name": "Minimum",
+      "cmd": "longest_incrementing_subslice(&[2, 1, 0, 1, 2, 5, 6])",
+      "expected": " &[0, 1, 2]"
     },
     {
-      "test": "test_06",
-      "name": "06",
-      "cmd": "hands_match(06)",
-      "expected": "1964"
-    },
-    {
-      "test": "test_07",
-      "name": "07",
-      "cmd": "hands_match(07)",
-      "expected": "2291"
-    },
-    {
-      "test": "test_08",
-      "name": "08",
-      "cmd": "hands_match(08)",
-      "expected": "2618"
-    },
-    {
-      "test": "test_09",
-      "name": "09",
-      "cmd": "hands_match(09)",
-      "expected": "2945"
-    },
-    {
-      "test": "test_10",
-      "name": "10",
-      "cmd": "hands_match(10)",
-      "expected": "3273"
-    },
-    {
-      "test": "test_11",
-      "name": "11",
-      "cmd": "hands_match(11)",
-      "expected": "0"
-    },
-    {
-      "test": "test_12",
-      "name": "12",
-      "cmd": "hands_match(12)",
-      "expected": "0"
+      "test": "test_max",
+      "name": "Maximum",
+      "cmd": "longest_incrementing_subslice(&[2, 5, 2, 253, 254, 255, 1])",
+      "expected": "&[253, 254, 255]"
     }
   ]
 }

--- a/exercises/rust-1-a/README.md
+++ b/exercises/rust-1-a/README.md
@@ -4,22 +4,17 @@ This is Part 1 of our research into how people write Rust in varying styles. Thi
 
 ## Instructions
 
-Your task is to find the moment when a clock's hands are perfectly aligned for a given hour. Given a standard 12-hour clock, with hour and minute hands which sweep continuously through time, there exists some second in each hour in which the hands are best lined up with each other.
+Your task is to find the longest incrementing subslice of a slice of integers. For example, given the slice `[1, 2, 4, 4, 5, 6, 7, 3, 2, 7, 8, 9, 1]`, the longest incrementing subslice is `[4, 5,6, 7]`, from indices `3` through `6` inclusive.
 
-We provide a stub method with the signature:
-
-```rust
-fn hands_match(hour: u8) -> u32
-```
-
-The range of possible values for `hour` is 1-12. The output must be the number of seconds after the hour at which the hands best line up.
-
-For example:
+We provide a function stub:
 
 ```rust
-// the clock's hands align at noon and midnight precisely
-assert_eq!(hands_match(12), 0);
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8]
 ```
+
+Note the signature: you should return a subsection of the input slice, not a newly-allocated vector.
+
+It is safe to assume that every input contains exactly one longest subslice.
 
 ## Troubleshooting
 

--- a/exercises/rust-1-a/example.rs
+++ b/exercises/rust-1-a/example.rs
@@ -1,35 +1,26 @@
-// input: the hour, 1-12 inclusive
-// output: seconds after the hour at which the hands are best aligned
-pub fn hands_match(mut hour: u8) -> u32 {
-    hour %= 12;
-    // let's solve this analytically.
-    //
-    // other plausible solution strategies:
-    // - brute force: iterate through the seconds, find the best match
-    // - binary search: if the minute hand position is greater than the
-    //   hour hand position, go back; otherwise, fwd
-    //
-    // to get the position of the hour hand (degrees) given the (fractional) hour:
-    //
-    //   h_hand = hour * 30
-    //
-    // to get the position of the minute hand (degrees) given the (fractional) hour:
-    //
-    //   m_hand = hour * 360
-    //
-    // note that the degree position of the hour and minute hands are not restricted
-    // to a standard 360 degree circle. the hand positions are still equal when
-    // the difference between the two is 360 * n for some n, where n is the number
-    // of times the minute hand has lapped the hour hand:
-    //
-    //   m_hand - h_hand = 360 * n
-    //   (hour * 360) - (hour * 30) = n * 360
-    //   330 * hour = n * 360
-    //   hour = n * 12 / 11
-    //
-    // however, this approach only finds the fractional hour for which the hands
-    // align; the problem asked for the seconds after the hour. Luckily, that's
-    // a straightforward modification:
-    //
-    ((hour as f64 * 12.0 / 11.0) % 1.0 * 3600.0).round() as u32
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8] {
+    // dynamic programming approach:
+
+    // longest subsequence length: for each index i, stores length of longest
+    // subsequence of s which ends at i
+    let mut lssl = vec![0; s.len()];
+
+    // last index: for each index i, stores last known index x at which s[x]==i
+    let mut lidx = vec![-1_isize; 256];
+
+    for idx in 0..s.len() {
+        // if the last position of the previous value is one less than the current
+        // index, then we can just continue the previous subsequence
+        if idx > 0 && s[idx] > 0 && (lidx[s[idx] as usize - 1] + 1) as usize == idx {
+            lssl[idx] = lssl[idx - 1] + 1;
+        } else {
+            // otherwise, this is the first index of a new sequence
+            lssl[idx] = 0;
+        }
+        lidx[s[idx] as usize] = idx as isize;
+    }
+
+    let (l, high) = lssl.iter().enumerate().map(|(i, l)| (l, i)).max().unwrap();
+    let low = high - l;
+    &s[low..=high]
 }

--- a/exercises/rust-1-a/src/lib.rs
+++ b/exercises/rust-1-a/src/lib.rs
@@ -1,5 +1,3 @@
-// input: the hour, 1-12 inclusive
-// output: seconds after the hour at which the hands are best aligned
-pub fn hands_match(mut hour: u8) -> u32 {
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8] {
     unimplemented!()
 }

--- a/exercises/rust-1-a/tests/rust_1_a.rs
+++ b/exercises/rust-1-a/tests/rust_1_a.rs
@@ -1,4 +1,4 @@
-use rust_1_a::hands_match;
+use rust_1_a::longest_incrementing_subslice;
 
 macro_rules! tests {
     ($test_func:ident {
@@ -15,18 +15,12 @@ macro_rules! tests {
 }
 
 tests! {
-    hands_match {
-        test_01(1,  327);
-        test_02(2,  655);
-        test_03(3,  982);
-        test_04(4,  1309);
-        test_05(5,  1636);
-        test_06(6,  1964);
-        test_07(7,  2291);
-        test_08(8,  2618);
-        test_09(9,  2945);
-        test_10(10, 3273);
-        test_11(11, 0); // these two cases are a fun degenerate result
-        test_12(12, 0); // can you work out why they act like this?
+    longest_incrementing_subslice {
+        test_example(&[1, 2, 4, 4, 5, 6, 7, 3, 2, 7, 8, 9, 1], &[4, 5, 6, 7]);
+        test_head(&[1, 2, 3, 5], &[1, 2, 3]);
+        test_tail(&[8, 1, 2, 3], &[1, 2, 3]);
+        test_full(&[1, 2, 3], &[1, 2, 3]);
+        test_min(&[2, 1, 0, 1, 2, 5, 6], &[0, 1, 2]);
+        test_max(&[2, 5, 2, 253, 254, 255, 1], &[253, 254, 255]);
     }
 }

--- a/exercises/rust-2-a/.meta/config.json
+++ b/exercises/rust-2-a/.meta/config.json
@@ -1,119 +1,82 @@
 {
-  "solution_files": ["src/lib.rs"],
+  "solution_files": [
+    "src/lib.rs"
+  ],
   "tests": [
     {
-      "test": "test_std_01",
-      "name": "std 01",
-      "cmd": "hands_match(&STANDARD, 01)",
-      "expected": "327"
+      "test": "test_old_example",
+      "name": "old example",
+      "cmd": "longest_increasing_subslices(&[1, 2, 4, 4, 5, 6, 7, 3, 2, 7, 8, 9, 1]",
+      "expected": "&[&[4, 5, 6, 7], &[2, 7, 8, 9]]"
     },
     {
-      "test": "test_std_02",
-      "name": "std 02",
-      "cmd": "hands_match(&STANDARD, 02)",
-      "expected": "655"
+      "test": "test_head",
+      "name": "head",
+      "cmd": "longest_increasing_subslices(&[1, 2, 3, 3]",
+      "expected": "&[&[1, 2, 3]]"
     },
     {
-      "test": "test_std_03",
-      "name": "std 03",
-      "cmd": "hands_match(&STANDARD, 03)",
-      "expected": "982"
+      "test": "test_tail",
+      "name": "tail",
+      "cmd": "longest_increasing_subslices(&[8, 1, 2, 3]",
+      "expected": "&[&[1, 2, 3]]"
     },
     {
-      "test": "test_std_04",
-      "name": "std 04",
-      "cmd": "hands_match(&STANDARD, 04)",
-      "expected": "1309"
+      "test": "test_full",
+      "name": "full",
+      "cmd": "longest_increasing_subslices(&[1, 2, 3]",
+      "expected": "&[&[1, 2, 3]]"
     },
     {
-      "test": "test_std_05",
-      "name": "std 05",
-      "cmd": "hands_match(&STANDARD, 05)",
-      "expected": "1636"
+      "test": "test_min",
+      "name": "min",
+      "cmd": "longest_increasing_subslices(&[2, 1, 0, 1, 2, 5, 6, 6]",
+      "expected": "&[&[0, 1, 2, 5, 6]]"
     },
     {
-      "test": "test_std_06",
-      "name": "std 06",
-      "cmd": "hands_match(&STANDARD, 06)",
-      "expected": "1964"
+      "test": "test_max",
+      "name": "max",
+      "cmd": "longest_increasing_subslices(&[2, 253, 253, 254, 255, 1]",
+      "expected": "&[&[253, 254, 255]]"
     },
     {
-      "test": "test_std_07",
-      "name": "std 07",
-      "cmd": "hands_match(&STANDARD, 07)",
-      "expected": "2291"
+      "test": "test_empty",
+      "name": "empty",
+      "cmd": "longest_increasing_subslices(&[], &[])"
     },
     {
-      "test": "test_std_08",
-      "name": "std 08",
-      "cmd": "hands_match(&STANDARD, 08)",
-      "expected": "2618"
+      "test": "test_no_increasing",
+      "name": "no increasing",
+      "cmd": "longest_increasing_subslices(&[4, 2, 1], &[])"
     },
     {
-      "test": "test_std_09",
-      "name": "std 09",
-      "cmd": "hands_match(&STANDARD, 09)",
-      "expected": "2945"
+      "test": "test_static",
+      "name": "static",
+      "cmd": "longest_increasing_subslices(&[5, 5, 5], &[])"
     },
     {
-      "test": "test_std_10",
-      "name": "std 10",
-      "cmd": "hands_match(&STANDARD, 10)",
-      "expected": "3273"
+      "test": "test_separated",
+      "name": "separated",
+      "cmd": "longest_increasing_subslices(&[10, 1, 3, 5, 0]",
+      "expected": "&[&[1, 3, 5]]"
     },
     {
-      "test": "test_std_11",
-      "name": "std 11",
-      "cmd": "hands_match(&STANDARD, 11)",
-      "expected": "0"
+      "test": "test_pair",
+      "name": "pair",
+      "cmd": "longest_increasing_subslices(&[5, 2, 3, 4, 4, 1, 3, 5, 0]",
+      "expected": "&[&[2, 3, 4], &[1, 3, 5]]"
     },
     {
-      "test": "test_std_12",
-      "name": "std 12",
-      "cmd": "hands_match(&STANDARD, 12)",
-      "expected": "0"
+      "test": "test_example",
+      "name": "example",
+      "cmd": "longest_increasing_subslices(&[5, 2, 3, 4, 4, 1, 3, 5, 0, 1]",
+      "expected": "&[&[2, 3, 4], &[1, 3, 5]]"
     },
     {
-      "test": "test_24_01",
-      "name": "24 01",
-      "cmd": "hands_match(&TWENTY_FOUR, 01)",
-      "expected": "157"
-    },
-    {
-      "test": "test_24_02",
-      "name": "24 02",
-      "cmd": "hands_match(&TWENTY_FOUR, 02)",
-      "expected": "313"
-    },
-    {
-      "test": "test_24_03",
-      "name": "24 03",
-      "cmd": "hands_match(&TWENTY_FOUR, 03)",
-      "expected": "470"
-    },
-    {
-      "test": "test_24_23",
-      "name": "24 23",
-      "cmd": "hands_match(&TWENTY_FOUR, 23)",
-      "expected": "0"
-    },
-    {
-      "test": "test_long_1",
-      "name": "long 1",
-      "cmd": "hands_match(&LONG_NOW, 1)",
-      "expected": "3504000000"
-    },
-    {
-      "test": "test_long_5",
-      "name": "long 5",
-      "cmd": "hands_match(&LONG_NOW, 5)",
-      "expected": "17520000000"
-    },
-    {
-      "test": "test_long_9",
-      "name": "long 9",
-      "cmd": "hands_match(&LONG_NOW, 9)",
-      "expected": "0"
+      "test": "test_triple",
+      "name": "triple",
+      "cmd": "longest_increasing_subslices(&[8, 9, 4, 5, 1, 2]",
+      "expected": "&[&[8, 9], &[4, 5], &[1, 2]]"
     }
   ]
 }

--- a/exercises/rust-2-a/.meta/start/1/src/lib.rs
+++ b/exercises/rust-2-a/.meta/start/1/src/lib.rs
@@ -1,15 +1,21 @@
-pub struct Hand {
-    pub name: &'static str, // for human-readable documentation only
-    pub qty: u32,           // how many intervals appear on the clock face
-    pub seconds: u64,       // how many seconds are in this period of time
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8] {
+    let mut lssl = vec![0; s.len()];
+    let mut lidx = vec![-1_isize; 256];
+
+    for idx in 0..s.len() {
+        if idx > 0 && s[idx] > 0 && (lidx[s[idx] as usize - 1] + 1) as usize == idx {
+            lssl[idx] = lssl[idx - 1] + 1;
+        } else {
+            lssl[idx] = 0;
+        }
+        lidx[s[idx] as usize] = idx as isize;
+    }
+
+    let (l, high) = lssl.iter().enumerate().map(|(i, l)| (l, i)).max().unwrap();
+    let low = high - l;
+    &s[low..=high]
 }
 
-pub struct Clock {
-    pub big: Hand,
-    pub little: Hand,
-}
-
-pub fn hands_match(_clock: &Clock, mut big_hand: u32) -> u64 {
-    big_hand %= 12;
-    ((big_hand as f64 * 12.0 / 11.0) % 1.0 * 3600.0).round() as u64
+pub fn longest_increasing_subslices<'a>(s: &'a [u8]) -> Vec<&'a [u8]> {
+    unimplemented!()
 }

--- a/exercises/rust-2-a/.meta/start/2/src/lib.rs
+++ b/exercises/rust-2-a/.meta/start/2/src/lib.rs
@@ -1,32 +1,19 @@
-pub struct Hand {
-    pub name: &'static str, // for human-readable documentation only
-    pub qty: u32,           // how many intervals appear on the clock face
-    pub seconds: u64,       // how many seconds are in this period of time
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8] {
+    let mut lssl = vec![0; s.len()];
+
+    for start_idx in 0..(s.len() - 1) {
+        for end_idx in (start_idx + 1)..s.len() {
+            if s[end_idx] < s[end_idx - 1] || s[end_idx] - s[end_idx - 1] != 1 {
+                break;
+            }
+            lssl[start_idx] = end_idx - start_idx;
+        }
+    }
+
+    let (longest, start) = lssl.iter().enumerate().map(|(i, v)| (v, i)).max().unwrap();
+    &s[start..=start + longest]
 }
 
-pub struct Clock {
-    pub big: Hand,
-    pub little: Hand,
-}
-
-pub fn hands_match(_clock: &Clock, mut big_hand: u32) -> u64 {
-    big_hand %= 12;
-
-    let (_, seconds) = (0..=3600)
-        .map(|seconds| (diff_degrees(big_hand, seconds), seconds))
-        .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Less))
-        .unwrap();
-    (seconds % 3600) as u64
-}
-
-fn big_hand_degrees(hour: u32, seconds: u32) -> f64 {
-    (hour as f64 * 30.0) + (seconds as f64 / 120.0)
-}
-
-fn little_hand_degrees(seconds: u32) -> f64 {
-    seconds as f64 / 10.0
-}
-
-fn diff_degrees(hour: u32, seconds: u32) -> f64 {
-    (big_hand_degrees(hour, seconds) - little_hand_degrees(seconds)).abs()
+pub fn longest_increasing_subslices<'a>(s: &'a [u8]) -> Vec<&'a [u8]> {
+    unimplemented!()
 }

--- a/exercises/rust-2-a/.meta/start/3/src/lib.rs
+++ b/exercises/rust-2-a/.meta/start/3/src/lib.rs
@@ -1,63 +1,19 @@
-pub struct Hand {
-    pub name: &'static str, // for human-readable documentation only
-    pub qty: u32,           // how many intervals appear on the clock face
-    pub seconds: u64,       // how many seconds are in this period of time
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8] {
+    let lssl: Vec<usize> = s
+        .iter()
+        .enumerate()
+        .map(|(start_idx, &v1)| {
+            s.iter()
+                .enumerate()
+                .skip(start_idx + 1)
+                .take_while(|(end_idx, &v2)| v2 > v1 && (v2 - v1) as usize == end_idx - start_idx)
+                .count()
+        })
+        .collect();
+    let (longest, start) = lssl.iter().enumerate().map(|(i, v)| (v, i)).max().unwrap();
+    &s[start..=start + longest]
 }
 
-pub struct Clock {
-    pub big: Hand,
-    pub little: Hand,
-}
-
-pub fn hands_match(_clock: &Clock, mut big_hand: u32) -> u64 {
-    big_hand %= 12;
-
-    // let (_, seconds) = (0..=3600)
-    //     .map(|seconds| (diff_degrees(big_hand, seconds), seconds))
-    //     .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Less))
-    //     .unwrap();
-    // (seconds % 3600) as u64
-
-    let mut range_min: u32 = 0;
-    let mut range_max: u32 = 3600;
-
-    loop {
-        if range_min >= range_max {
-            break;
-        }
-
-        let center = (range_min + range_max) / 2;
-        if range_min == center {
-            break;
-        }
-
-        let dd = diff_degrees(big_hand, center);
-        if dd < 0.0 {
-            range_max = center;
-        } else if dd > 0.0 {
-            range_min = center;
-        }
-    }
-
-    // the subsequent diff might actually be smaller
-    let rmdiff = diff_degrees(big_hand, range_min).abs();
-    let subsdiff = diff_degrees(big_hand, range_min + 1).abs();
-    let out = if subsdiff < rmdiff {
-        (range_min + 1) as u64
-    } else {
-        range_min as u64
-    };
-    out % 3600
-}
-
-fn big_hand_degrees(hour: u32, seconds: u32) -> f64 {
-    (hour as f64 * 30.0) + (seconds as f64 / 120.0)
-}
-
-fn little_hand_degrees(seconds: u32) -> f64 {
-    seconds as f64 / 10.0
-}
-
-fn diff_degrees(hour: u32, seconds: u32) -> f64 {
-    (big_hand_degrees(hour, seconds) - little_hand_degrees(seconds))
+pub fn longest_increasing_subslices<'a>(s: &'a [u8]) -> Vec<&'a [u8]> {
+    unimplemented!()
 }

--- a/exercises/rust-2-a/README.md
+++ b/exercises/rust-2-a/README.md
@@ -4,41 +4,39 @@ This is Part 2 of our research into how people write Rust in varying styles. Thi
 
 ## Instructions
 
-Your task is to extend existing code with new functionality. The code you'll be working with has a function named `hands_match`, which finds the moment when a clock's hour and minute hands are perfectly aligned for a given hour, on a standard, 12-hour clock.
+Your task is to extend existing code with new functionality. The code you'll be working with has a function named `longest_incrementing_subslice`, which finds the longest contiguous subslice of an input slice for which each member is 1 higher than its predecessor:
 
 ```rust
-fn hands_match(clock: &Clock, big_hand: u32) -> u64
+pub fn longest_incrementing_subslice(s: &[u8]) -> &[u8]
 ```
 
-You need to extend this function so it computes the correct results on nonstandard clocks. You may have seen [24-hour clocks](https://i.pinimg.com/originals/d0/0c/c2/d00cc2c17993ca8e1faf603fbd308d27.png) in the past; in this portion of the exercise, you will solve for those and [others](https://en.wikipedia.org/wiki/Clock_of_the_Long_Now).
+You need to write a new function, `longest_increasing_subslices`, which differs from `longest_incrementing_subslice` in two ways:
 
-A standard 12-hour clock is constructed like this:
+- Increasing subslices are still contiguous, but members may be any positive amount higher than their predecessor, not just 1
+- There may be any number of increasing subslices present in the input; you must output all of the longest.
 
 ```rust
-const STANDARD: Clock = Clock {
-    big: Hand {
-        name: "hour",
-        qty: 12,
-        seconds: 3600,
-    },
-    little: Hand {
-        name: "minute",
-        qty: 60,
-        seconds: 60,
-    },
-}
+pub fn longest_increasing_subslices<'a>(s: &'a [u8]) -> Vec<&'a [u8]>
 ```
-
-The output must be the number of seconds after the previous big hand interval at which the hands line up.
 
 For example:
 
 ```rust
-// on a standard clock, the clock's hands align at noon and midnight precisely
-assert_eq!(hands_match(&STANDARD, 12), 0);
+assert_eq!(
+    longest_increasing_subslices(&[5, 2, 3, 4, 4, 1, 3, 5, 0, 1]),
+    &[&[2, 3, 4], &[1, 3, 5]],
+);
 ```
 
-It is safe to assume that `clock.little.seconds` is a multiple of `clock.big.seconds`.
+## Notes
+
+If there are no increasing subslices, return an empty vector.
+
+The return vector must be sorted according to the initial index of the returned slices.
+
+As before, you must return subslices of the initial slice, not copy the data.
+
+You may do whatever you wish with the existing `longest_incrementing_subslice` implementation: modify it, call it, ignore it; there are no restrictions, it is provided only for inspiration.
 
 ## Troubleshooting
 

--- a/exercises/rust-2-a/example.rs
+++ b/exercises/rust-2-a/example.rs
@@ -1,46 +1,29 @@
-pub struct Hand {
-    pub name: &'static str, // for human-readable documentation only
-    pub qty: u32,           // how many intervals appear on the clock face
-    pub seconds: u64,       // how many seconds are in this period of time
-}
+pub fn longest_increasing_subslices<'a>(s: &'a [u8]) -> Vec<&'a [u8]> {
+    // dynamic programming approach:
 
-pub struct Clock {
-    pub big: Hand,
-    pub little: Hand,
-}
+    // longest subsequence length: for each index i, stores length of longest
+    // subsequence of s which ends at i
+    let mut lssl = vec![0; s.len()];
 
-pub fn hands_match(clock: &Clock, mut big_hand: u32) -> u64 {
-    big_hand %= clock.big.qty;
-    // let's solve this analytically.
-    //
-    // other plausible solution strategies:
-    // - brute force: iterate through the seconds, find the best match
-    // - binary search: if the minute hand position is greater than the
-    //   big_hand hand position, go back; otherwise, fwd
-    //
-    // to get the position of the big hand (degrees) given the (fractional) big_hand_f:
-    //
-    //   b_hand = big_hand * (360 / clock.big.qty)
-    //
-    // to get the position of the little hand (degrees) given the (fractional) big_hand_f:
-    //
-    //   m_hand = big_hand * 360
-    //
-    // note that the degree position of the big and little hands are not restricted
-    // to a standard 360 degree circle. the hand positions are still equal when
-    // the difference between the two is 360 * n for some n, where n is the number
-    // of times the little hand has lapped the big hand:
-    //
-    //   m_hand - h_hand = 360 * n
-    //   (big_hand * 360) - (big_hand * (360 / clock.big.qty)) = n * 360
-    //   big_hand * 360 * (1 - (1/clock.big.qty)) = n * 360
-    //   big_hand * (1 - (1 / clock.big.qty)) = n
-    //   big_hand = n / (1 - (1 / clock.big.qty))
-    //
-    // however, this approach only finds the fractional hour for which the hands
-    // align; the problem asked for the seconds after the hour. Luckily, that's
-    // a straightforward modification:
-    //
-    ((big_hand as f64 / (1.0 - (1.0 / clock.big.qty as f64))) % 1.0 * (clock.big.seconds as f64))
-        .round() as u64
+    // last index: for each index i, stores last known index x at which s[x]==i
+    let mut lidx = vec![-1_isize; 256];
+
+    for idx in 0..s.len() {
+        if idx > 0 &&  s[idx] > s[idx-1] {
+            lssl[idx] = lssl[idx - 1] + 1;
+        } else {
+            // otherwise, this is the first index of a new sequence
+            lssl[idx] = 0;
+        }
+        lidx[s[idx] as usize] = idx as isize;
+    }
+
+    let mut out = Vec::new();
+    if let Some(len) = lssl.iter().filter(|&&l| l > 0).max() {
+        for (high, _) in lssl.iter().enumerate().filter(|&(_, l)| l == len) {
+            let low = high - len;
+            out.push(&s[low..=high]);
+        }
+    }
+    out
 }

--- a/exercises/rust-2-a/tests/rust_2_a.rs
+++ b/exercises/rust-2-a/tests/rust_2_a.rs
@@ -1,78 +1,34 @@
-use rust_2_a::{hands_match, Clock, Hand};
+use rust_2_a::longest_increasing_subslices;
 
 macro_rules! tests {
     ($test_func:ident {
-        $( $(#[$attr:meta])* $test_name:ident($expect:expr, $( $param:expr ),*); )+
+        $( $(#[$attr:meta])* $test_name:ident($param:expr, $expect:expr); )+
     }) => {
         $(
             $(#[$attr])*
             #[test]
             fn $test_name() {
-                assert_eq!($test_func( $( $param ),* ), $expect);
+                let expect: &[&[u8]] = $expect;
+                assert_eq!($test_func( $param ), expect);
             }
         )+
     }
 }
 
-const STANDARD: Clock = Clock {
-    big: Hand {
-        name: "hour",
-        qty: 12,
-        seconds: 3600,
-    },
-    little: Hand {
-        name: "minute",
-        qty: 60,
-        seconds: 60,
-    },
-};
-
-const TWENTY_FOUR: Clock = Clock {
-    big: Hand {
-        name: "hour",
-        qty: 24,
-        seconds: 3600,
-    },
-    little: Hand {
-        name: "minute",
-        qty: 60,
-        seconds: 60,
-    },
-};
-
-const LONG_NOW: Clock = Clock {
-    big: Hand {
-        name: "millenium",
-        qty: 10,
-        seconds: 60 * 60 * 24 * 365 * 1000,
-    },
-    little: Hand {
-        name: "century",
-        qty: 100,
-        seconds: 60 * 60 * 24 * 365 * 100,
-    },
-};
-
 tests! {
-    hands_match {
-        test_std_01(327,  &STANDARD, 1);
-        test_std_02(655,  &STANDARD, 2);
-        test_std_03(982,  &STANDARD, 3);
-        test_std_04(1309, &STANDARD, 4);
-        test_std_05(1636, &STANDARD, 5);
-        test_std_06(1964, &STANDARD, 6);
-        test_std_07(2291, &STANDARD, 7);
-        test_std_08(2618, &STANDARD, 8);
-        test_std_09(2945, &STANDARD, 9);
-        test_std_10(3273, &STANDARD, 10);
-        test_std_11(0,    &STANDARD, 11);
-        test_std_12(0,    &STANDARD, 12);
-        test_24_01(157,   &TWENTY_FOUR, 1);
-        test_24_02(313,   &TWENTY_FOUR, 2);
-        test_24_03(470,   &TWENTY_FOUR, 3);
-        test_24_23(0,     &TWENTY_FOUR, 23);
-        test_long_1(3504000000,   &LONG_NOW, 1);
-        test_long_5(17520000000,   &LONG_NOW, 5);
-        test_long_9(0,   &LONG_NOW, 9);
+    longest_increasing_subslices {
+        test_old_example(&[1, 2, 4, 4, 5, 6, 7, 3, 2, 7, 8, 9, 1], &[&[4, 5, 6, 7], &[2, 7, 8, 9]]);
+        test_head(&[1, 2, 3, 3], &[&[1, 2, 3]]);
+        test_tail(&[8, 1, 2, 3], &[&[1, 2, 3]]);
+        test_full(&[1, 2, 3], &[&[1, 2, 3]]);
+        test_min(&[2, 1, 0, 1, 2, 5, 6, 6], &[&[0, 1, 2, 5, 6]]);
+        test_max(&[2, 253, 253, 254, 255, 1], &[&[253, 254, 255]]);
+        test_empty(&[], &[]);
+        test_no_increasing(&[4, 2, 1], &[]);
+        test_static(&[5, 5, 5], &[]);
+        test_separated(&[10, 1, 3, 5, 0], &[&[1, 3, 5]]);
+        test_pair(&[5, 2, 3, 4, 4, 1, 3, 5, 0], &[&[2, 3, 4], &[1, 3, 5]]);
+        test_example(&[5, 2, 3, 4, 4, 1, 3, 5, 0, 1], &[&[2, 3, 4], &[1, 3, 5]]);
+        test_triple(&[8, 9, 4, 5, 1, 2], &[&[8, 9], &[4, 5], &[1, 2]]);
     }
 }


### PR DESCRIPTION
The clock hands problem for rust-1-a was deemed too hard. This commit
rewrites both parts into new problems: longest incrementing subslice, and longest increasing subslices.