### PR TITLE
[Python] Fix Typos

### DIFF
--- a/exercises/python-1-b/.meta/config.json
+++ b/exercises/python-1-b/.meta/config.json
@@ -23,7 +23,7 @@
     {
       "test": "TestTransmit.test_only_ascii_alphanum",
       "name": "Only ASCII alphanum",
-      "cmd": "receive(\"\\N{GREEK CAPITAL LETTER NU}\\N{CHEROKEE LETTER TLI}\\N{CHEROKEE LETTER TLI}-1701-\\N{CHEROKEE LETTER A}\" + string.whitespace + string.punctuation\")",
+      "cmd": "transmit(\"\\N{GREEK CAPITAL LETTER NU}\\N{CHEROKEE LETTER TLI}\\N{CHEROKEE LETTER TLI}-1701-\\N{CHEROKEE LETTER A}\" + string.whitespace + string.punctuation\")",
       "expected": "\"ONE SEVEN ZERO ONE\""
     },
     {

--- a/exercises/python-2-b/.meta/config.json
+++ b/exercises/python-2-b/.meta/config.json
@@ -23,7 +23,7 @@
     {
       "test": "TestTransmit.test_only_ascii_alphanum",
       "name": "Transmit only ASCII alphanum",
-      "cmd": "receive(\"\\N{GREEK CAPITAL LETTER NU}\\N{CHEROKEE LETTER TLI}\\N{CHEROKEE LETTER TLI}-1701-\\N{CHEROKEE LETTER A}\" + string.whitespace + string.punctuation\")",
+      "cmd": "transmit(\"\\N{GREEK CAPITAL LETTER NU}\\N{CHEROKEE LETTER TLI}\\N{CHEROKEE LETTER TLI}-1701-\\N{CHEROKEE LETTER A}\" + string.whitespace + string.punctuation\")",
       "expected": "\"ONE SEVEN ZERO ONE\""
     },
     {


### PR DESCRIPTION
A couple of tests had transposed function names. Thanks to user Yoni (ynfle) for catching these.