### PR TITLE
Rename variable in JavaScript examples

### DIFF
--- a/exercises/javascript-1-a/README.md
+++ b/exercises/javascript-1-a/README.md
@@ -14,7 +14,7 @@ It returns a _new array_ with the `item` moved from the position `from` to the p
 
 ```javascript
 const before = ['❤ A', '❤ 9', '❤ 3', '❤ 6', '♣ A']
-const magics = arrange(original, 1, -2)
+const magics = arrange(before, 1, -2)
 magics
 // => ['❤ A', '❤ 3', '❤ 6', '❤ 9', '♣ A']
 //                          ^--- has moved from position 1 to -2 (from the right side)

--- a/exercises/javascript-2-a/README.md
+++ b/exercises/javascript-2-a/README.md
@@ -24,7 +24,7 @@ It returns a _new array_ with the `item` moved from the position `from` to the p
 
 ```javascript
 const before = ["❤ A", "❤ 9", "❤ 3", "❤ 6", "♣ A"];
-const magics = arrange(original, [[1, -2]]);
+const magics = arrange(before, [[1, -2]]);
 magics;
 // => ['❤ A', '❤ 3', '❤ 6', '❤ 9', '♣ A']
 //                          ^--- has moved from position 1 to -2 (from the right side)


### PR DESCRIPTION
The first JavaScript example for the decks exercise uses an undeclared variable `original`, which should be `before` instead.