### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -137,7 +137,7 @@
     },
     {
       "slug": "javascript-1-b",
-      "uuid": "c1445866-57ca-11ea-82b4-0242ac130003",
+      "uuid": "a8e0d0ca-d8c8-4e3c-91a2-5e9c815d472d",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -145,7 +145,7 @@
     },
     {
       "slug": "javascript-2-b",
-      "uuid": "73a27680-57cd-11ea-82b4-0242ac130003",
+      "uuid": "1b34a2cc-1e19-4f85-b45a-b1b63b0fa63b",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
